### PR TITLE
Add specific version install for torch and torchvision

### DIFF
--- a/ENTAR_Eng.ipynb
+++ b/ENTAR_Eng.ipynb
@@ -118,6 +118,8 @@
         "!pip install youtube_dl\n",
         "!pip install ffmpeg\n",
         "!pip install ffmpeg-python\n",
+        "!pip install torchvision==0.5\n",
+        "!pip install torch==1.4\n",
         "\n",
         "from IPython.display import clear_output\n",
         "from google.colab import files\n",

--- a/ENTAR_Rus.ipynb
+++ b/ENTAR_Rus.ipynb
@@ -140,6 +140,8 @@
         "!pip install youtube_dl\n",
         "!pip install ffmpeg\n",
         "!pip install ffmpeg-python\n",
+        "!pip install torchvision==0.5\n",
+        "!pip install torch==1.4\n",
         "\n",
         "from IPython.display import clear_output\n",
         "from google.colab import files\n",


### PR DESCRIPTION
Got a problem on Google Colab:
– By default Colab install latest `torch` and `torchvision` which aren't supported by current EDVR version. 
– Add explicit install to first step of `torch==1.4` and `torchvision==0.5.0`.
– Problem was solved